### PR TITLE
Changed default content-type for unknown file extensions from 'text/plain' to 'application/octet-stream' to handle all unknown files as binary data and prompt user to save the file instead of displaying it in the browser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn content_type_middleware<B>(req: Request<B>, next: Next<B>) -> Respo
             "rtf" => "application/rtf",
             "odt" => "application/vnd.oasis.opendocument.text",
             "ods" => "application/vnd.oasis.opendocument.spreadsheet",
-            _ => "text/plain",
+            _ => "application/octet-stream",
         };
 
         if let Ok(content_type) = content_type.parse() {


### PR DESCRIPTION
It would be appropriate to serve the file with the "application/octet-stream" content-type.
This is a general content-type that indicates that the data is in binary format and may not be human-readable.
It is a safe option to use when the file type is unknown, as it will allow the user's browser to handle the file in the most appropriate way.