### PR TITLE
add content-type for wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub async fn content_type_middleware<B>(req: Request<B>, next: Next<B>) -> Respo
             "rtf" => "application/rtf",
             "odt" => "application/vnd.oasis.opendocument.text",
             "ods" => "application/vnd.oasis.opendocument.spreadsheet",
+            "wasm" => "application/wasm",
             _ => "application/octet-stream",
         };
 


### PR DESCRIPTION
I am creating a Leptos app and serving it's static assets with this package, but the wrong content-type gives a warning in the console when loading the page:

> `WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:
 TypeError: WebAssembly: Response has unsupported MIME type 'application/octet-stream' expected 'application/wasm'